### PR TITLE
fix NaN 0 bug in decomp serice, made trig rigorous in latex gen

### DIFF
--- a/src/generators/latexGenerators.js
+++ b/src/generators/latexGenerators.js
@@ -160,15 +160,17 @@ export function infiniteGeometricSeries(n, useGammaFunction) {
  * @returns {string} LaTeX string
  */
 export function trigIdentity(n, randOption) {
+  const a = Math.floor(Math.random() * 51) - 10; // Random number from -10 to 40
+  
   if (n > 0) {
     const randomValue = Math.random();
     if (randomValue < 0.25) {
-      return `\\left({${randOption(n)} \\over {(\\cos^2x + \\sin^2x)}}\\right)`;
+      return `\\left({${randOption(n)} \\over {\\lim_{{x\\to ${a}}}(\\cos^2x + \\sin^2x)}}\\right)`;
     }
     if (randomValue < 0.5) {
-      return `\\left({${randOption(n)} \\times (\\cos^2x + \\sin^2x)}\\right)`;
+      return `\\left({${randOption(n)} \\times \\lim_{{x\\to ${a}}}(\\cos^2x + \\sin^2x)}\\right)`;
     }
-    return `\\left({${randOption(n + 1)} - (\\cos^2x + \\sin^2x)}\\right)`;
+    return `\\left({${randOption(n + 1)} - \\lim_{{x\\to ${a}}}(\\cos^2x + \\sin^2x)}\\right)`;
   }
-  return `\\left({${randOption(n + 1)} - (\\cos^2x + \\sin^2x)}\\right)`;
+  return `\\left({${randOption(n + 1)} - \\lim_{{x\\to ${a}}}(\\cos^2x + \\sin^2x)}\\right)`;
 }

--- a/src/services/decompositionService.js
+++ b/src/services/decompositionService.js
@@ -151,7 +151,7 @@ export function decompose(n, possibleOptions, sameNumber) {
   const randomValue = Math.random();
 
   // Strategy 1: Factor decomposition - ab = (a - c)(b + c) + c(b - a + c)
-  if (n < MEDIUM_NUMBER_THRESHOLD && (n === 2 || !isPrime(n)) && randomValue < 0.25) {
+  if (parseInt(n) !== 0 && n < MEDIUM_NUMBER_THRESHOLD && (n === 2 || !isPrime(n)) && randomValue < 0.25) {
     const factors = getFactors(parseInt(n));
     const randomIndex = randomInt(0, factors.length - 1);
     const a = factors[randomIndex];


### PR DESCRIPTION
Hey, nice refactor! 

Anyway here are the same 2 bugs from 2023 that still need fixing 🥀
i beg, please fix these they are actually bugging me so much @enjeck 

1. 0 decomposition results in nan and undefined: https://github.com/enjeck/num2math/issues/21 https://github.com/enjeck/num2math/pull/22 this is fixed in decomposition service b y excluding 0
2. cosine and sine are not rigorous 🥀💔 you are making an equation, not a computable expression, please fix this, you dont have to copy my limit values but at least add a limit that you like by editing my PR or something pls

i discarded my original PR https://github.com/enjeck/num2math/pull/23 and had to go through all your new refactored code for this xd